### PR TITLE
Use idiomatic Django to reference static files

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,13 +58,14 @@ def event_detail(request, id):
 
 ```html+django
 {% load inertia_tags %}
+{% load static %}
 <!DOCTYPE html>
 <html  class="h-full bg-gray-200">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <script src="{{ STATIC_URL}}dist/app.js" defer></script>
-    <link href="{{ STATIC_URL}}dist/app.css" rel="stylesheet" />
+    <script src="{% static 'dist/app.js' %}" defer></script>
+    <link href="{% static 'dist/app.css' %}" rel="stylesheet" />
   </head>
   <body>
     {% inertia %}


### PR DESCRIPTION
Hi @girardinsamuel!

Just thought to improve the docs a bit by using Django's static template tag to reference the generated JS and CSS files in the template. I believe this is more idiomatic Django over using using `{{ STATIC_URL }}` directly in the template (unless there's another reason that I'm not aware of for it).

Reference: https://docs.djangoproject.com/en/4.0/howto/static-files/#configuring-static-files

Great work with this library btw 👍👍

Thanks!