### PR TITLE
Fix: ensure valid JSON string is generated in the data-page attr

### DIFF
--- a/django_inertia/templatetags/inertia_tags.py
+++ b/django_inertia/templatetags/inertia_tags.py
@@ -1,3 +1,5 @@
+import json
+
 from django import template
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
@@ -8,4 +10,6 @@ register = template.Library()
 @register.simple_tag(takes_context=True)
 def inertia(context, app_id="app"):
     page = context["page__"]
-    return format_html('<div id="{}" data-page="{}"></div>', mark_safe(app_id), mark_safe(page))
+    return format_html(
+        "<div id=\"{}\" data-page='{}'></div>", mark_safe(app_id), mark_safe(json.dumps(page))
+    )

--- a/tests/test_template_tag.py
+++ b/tests/test_template_tag.py
@@ -1,3 +1,5 @@
+import json
+
 from django.template import Context, Template
 from django.test import TestCase
 
@@ -37,3 +39,26 @@ class TestInertiaTemplateTag(TestCase):
             )
         )
         assert 'id="my_app"' in rendered
+
+    def test_data_page_valid_json(self):
+        rendered = Template("{% load inertia_tags %} {% inertia %}").render(
+            Context(
+                {
+                    "page__": {
+                        "component": "Index",
+                        "url": "/",
+                        "props": {"message": "Hello"},
+                        "version": "1",
+                    }
+                }
+            )
+        )
+
+        # Assert that a JSON-parsable string is found in the data-page attr
+        json_parsable_context_string = (
+            '{"component": "Index", "url": "/", "props": {"message": "Hello"}, "version": "1"}'
+        )
+        assert f"data-page='{json_parsable_context_string}'" in rendered
+
+        # Assert that the data-page attr value is a valid JSON string
+        assert type(json.loads(json_parsable_context_string)) == dict


### PR DESCRIPTION
This pull request is a fix for #7. Thanks!